### PR TITLE
add -x option to bind to a specific IPv4 IP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.nfs*
+*.o
+Makefile
+config.h
+config.log
+config.status
+srelay

--- a/main.c
+++ b/main.c
@@ -46,6 +46,7 @@ char *ident = "srelay";
 char *pidfile = PIDFILE;
 char *pwdfile = NULL;
 char *bindtodevice = NULL;
+char *bindout = NULL;
 pid_t master_pid;
 
 #if USE_THREAD
@@ -93,6 +94,7 @@ void usage()
 #ifdef SO_BINDTODEVICE
 	  "\t-J i/f\toutbound interface name\n"
 #endif
+	  "\t-x ipv4\tuse ipv4 literal for outbound connections (probably conflicts with -J and -g)\n"
 	  "\t-m num\tmax child/thread\n"
 	  "\t-o min\tidle timeout minutes\n"
 	  "\t-p file\tpid file\n"
@@ -432,7 +434,7 @@ int main(int ac, char **av)
 
   openlog(ident, LOG_PID | LOG_NDELAY, SYSLOGFAC);
 
-  while((ch = getopt(ac, av, "a:c:i:J:m:o:p:u:frstbwgIqvh?")) != -1)
+  while((ch = getopt(ac, av, "a:c:i:x:J:m:o:p:u:frstbwgIqvh?")) != -1)
     switch (ch) {
     case 'a':
       if (optarg != NULL) {
@@ -494,6 +496,12 @@ int main(int ac, char **av)
       }
       break;
 #endif
+
+    case 'x':
+      if (optarg != NULL) {
+	bindout = strdup(optarg);
+      }
+      break;
 
     case 'o':
       if (optarg != NULL) {

--- a/socks.c
+++ b/socks.c
@@ -1257,6 +1257,23 @@ int forward_connect(SOCKS_STATE *state)
       }
     }
 
+    if (bindout) {
+      struct sockaddr_in localaddr;
+      memset(&localaddr, 0, sizeof(struct sockaddr_in));
+      if (inet_aton(bindout, &localaddr.sin_addr) == 0) {
+        /* inet_aton error */
+        error = EINVAL;
+        close(cs);
+        continue;
+      }
+      if (bind(cs, (struct sockaddr *) &localaddr, sizeof(localaddr)) <0) {
+	/* bind error */
+	error = errno;
+	close(cs);
+	continue;
+      }
+    }
+
     if (connect(cs, res->ai_addr, res->ai_addrlen) < 0) {
       /* connect fail */
       error = errno;

--- a/srelay.h
+++ b/srelay.h
@@ -392,6 +392,7 @@ extern char method_tab[];
 extern int method_num;
 extern int bind_restrict;
 extern int same_interface;
+extern char *bindout;
 #ifdef HAVE_LIBWRAP
 extern int use_tcpwrap;
 #endif /* HAVE_LIBWRAP */


### PR DESCRIPTION
Calls bind(2) on outbound sockets to set the source IP to use.

I couldn't get the `-J` option to work, it fails no matter which interface name I passed to it (and I want to bind to a specific IP, not a specific interface), and the `-g` option makes no sense to me.  Seems you can get the same kind of functionality with `-x`.  I guess you'd use `-g` if you were listening for connections on multiple interfaces?

Only tested with IPv4, I did not add IPv6 support.  I didn't test what would happen if the outbound socket was IPv6 and this option was used.
